### PR TITLE
Add grf_path option in patch definition

### DIFF
--- a/examples/patch.yml
+++ b/examples/patch.yml
@@ -9,3 +9,6 @@ entries:
     is_removed: true
   # Add all the files that the (local) folder contains
   - relative_path: data\model
+  # Change the path in the grf.
+  - relative_path: data-release\clientinfo.xml
+    in_grf_path: data\sclientinfo.xml

--- a/mkpatch/src/main.rs
+++ b/mkpatch/src/main.rs
@@ -96,6 +96,8 @@ where
     )?;
     for entry in patch_definition.entries {
         let win32_relative_path = win32_path(&entry.relative_path);
+        let target_win32_relative_path = entry.grf_path.unwrap_or(win32_relative_path.clone());
+
         if entry.is_removed {
             log::trace!("'{}' will be REMOVED", &win32_relative_path);
             archive_builder.append_file_removal(win32_relative_path);
@@ -107,9 +109,9 @@ where
             .join(posix_path(entry.relative_path));
         if native_path.is_file() {
             // Path points to a single file
-            log::trace!("'{}' will be UPDATED", &win32_relative_path);
+            log::trace!("'{}' will be UPDATED", &target_win32_relative_path);
             let file = File::open(native_path)?;
-            archive_builder.append_file_update(win32_relative_path, file)?;
+            archive_builder.append_file_update(target_win32_relative_path, file)?;
         } else if native_path.is_dir() {
             // Path points to a directory
             append_directory_update(

--- a/mkpatch/src/main.rs
+++ b/mkpatch/src/main.rs
@@ -96,7 +96,7 @@ where
     )?;
     for entry in patch_definition.entries {
         let win32_relative_path = win32_path(&entry.relative_path);
-        let target_win32_relative_path = entry.grf_path.unwrap_or(win32_relative_path.clone());
+        let target_win32_relative_path = entry.in_grf_path.unwrap_or(win32_relative_path.clone());
 
         if entry.is_removed {
             log::trace!("'{}' will be REMOVED", &win32_relative_path);

--- a/mkpatch/src/patch_definition.rs
+++ b/mkpatch/src/patch_definition.rs
@@ -19,6 +19,7 @@ pub struct PatchEntry {
     pub relative_path: String,
     #[serde(default)] // Defaults to false
     pub is_removed: bool,
+    pub grf_path: Option<String>
 }
 
 pub fn parse_patch_definition(file_path: impl AsRef<Path>) -> Result<PatchDefinition> {

--- a/mkpatch/src/patch_definition.rs
+++ b/mkpatch/src/patch_definition.rs
@@ -19,7 +19,7 @@ pub struct PatchEntry {
     pub relative_path: String,
     #[serde(default)] // Defaults to false
     pub is_removed: bool,
-    pub grf_path: Option<String>
+    pub in_grf_path: Option<String>
 }
 
 pub fn parse_patch_definition(file_path: impl AsRef<Path>) -> Result<PatchDefinition> {


### PR DESCRIPTION
I'd like a way to change the path of the file I want to add to the generated .thor file.

For example, if this is my client directory:
```
data/
    resmapnametable.txt
    sclientinfo.xml
data-release/
    sclientinfo.xml
data.grf
rdata.grf
client.exe
```

`data/sclientinfo.xml` is my development file, it has a server connection to localhost instead of the release server.

`data-release/sclientinfo.xml` is the file I want to be merged into the grf.

I'd like to add an option to the patch definition file, `grf_path`, that will be the path used to write into the thor file, like so:
```YAML
# Definition of the actual patch content
entries:
  - relative_path: data-release\sclientinfo.xml
    grf_path: data\sclientinfo.xml
```